### PR TITLE
feat: scaffold basic scenes and placeholders

### DIFF
--- a/public/city.svg
+++ b/public/city.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="0" y="50" width="100" height="50" fill="gray" />
+  <rect x="10" y="40" width="20" height="60" fill="silver" />
+  <rect x="40" y="30" width="20" height="70" fill="lightgray" />
+  <rect x="70" y="45" width="20" height="55" fill="darkgray" />
+</svg>

--- a/public/kaiju.svg
+++ b/public/kaiju.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="green" />
+  <circle cx="35" cy="40" r="5" fill="white" />
+  <circle cx="65" cy="40" r="5" fill="white" />
+  <rect x="45" y="60" width="10" height="15" fill="red" />
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -1,30 +1,25 @@
 .App {
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  text-align: center;
+  color: white;
   background-color: #282c34;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
-#game-container {
+.menu button {
+  margin: 0.5rem;
+}
+
+.level-screen {
+  color: white;
   text-align: center;
 }
 
-.character {
-  width: 150px;
-  height: 150px;
-  cursor: pointer;
-}
-
-.bounce {
-  animation: bounce 0.5s ease;
-}
-
-@keyframes bounce {
-  0%, 100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-20px);
-  }
+.sprites img {
+  width: 32px;
+  height: 32px;
+  margin: 0.5rem;
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,6 +3,6 @@ import App from './App';
 
 test('renders start menu', () => {
   render(<App />);
-  const button = screen.getByText(/Start Game/i);
-  expect(button).toBeInTheDocument();
+  expect(screen.getByText(/Start Game/i)).toBeInTheDocument();
+  expect(screen.getByText(/Options/i)).toBeInTheDocument();
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders character', () => {
+test('renders start menu', () => {
   render(<App />);
-  const img = screen.getByAltText(/character/i);
-  expect(img).toBeInTheDocument();
+  const button = screen.getByText(/Start Game/i);
+  expect(button).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,81 @@
-import { useState } from 'react';
-import character from './character.svg';
+import React, { useState } from 'react';
+import {
+  KaijuConfig,
+  ScoreRecord,
+} from './types';
+import { Start } from './scenes/Start';
+import { CreateKaiju } from './scenes/CreateKaiju';
+import { SelectCity } from './scenes/SelectCity';
+import { Level } from './scenes/Level';
+import { Score } from './scenes/Score';
+import { HighScores } from './scenes/HighScores';
 import './App.css';
 
+type Scene =
+  | { name: 'start' }
+  | { name: 'create' }
+  | { name: 'select'; config: KaijuConfig }
+  | { name: 'level'; config: KaijuConfig; city: string }
+  | { name: 'score'; score: number }
+  | { name: 'highscores' };
+
 function App() {
-  const [bouncing, setBouncing] = useState(false);
+  const [scene, setScene] = useState<Scene>({ name: 'start' });
+  const [scores, setScores] = useState<ScoreRecord[]>([]);
 
-  const handleClick = () => {
-    setBouncing(true);
-  };
-
-  return (
-    <div className="App">
-      <div id="game-container">
-        <img
-          src={character}
-          alt="character"
-          className={`character ${bouncing ? 'bounce' : ''}`}
-          onClick={handleClick}
-          onAnimationEnd={() => setBouncing(false)}
+  switch (scene.name) {
+    case 'start':
+      return (
+        <Start
+          onStartGame={() => setScene({ name: 'create' })}
+          onViewHighScores={() => setScene({ name: 'highscores' })}
         />
-      </div>
-    </div>
-  );
+      );
+    case 'create':
+      return (
+        <CreateKaiju
+          onContinue={(config) => setScene({ name: 'select', config })}
+        />
+      );
+    case 'select':
+      return (
+        <SelectCity
+          onBegin={(city) =>
+            setScene({ name: 'level', config: scene.config, city })
+          }
+        />
+      );
+    case 'level':
+      return (
+        <Level
+          config={scene.config}
+          city={scene.city}
+          onGameOver={(score) => {
+            const record: ScoreRecord = {
+              id: Date.now().toString(),
+              kaiju: scene.config,
+              city: scene.city,
+              score,
+              createdAt: new Date().toISOString(),
+            };
+            setScores((prev) => [...prev, record]);
+            setScene({ name: 'score', score });
+          }}
+        />
+      );
+    case 'score':
+      return (
+        <Score
+          score={scene.score}
+          onPlayAgain={() => setScene({ name: 'start' })}
+          onViewHighScores={() => setScene({ name: 'highscores' })}
+        />
+      );
+    case 'highscores':
+      return <HighScores scores={scores} onBack={() => setScene({ name: 'start' })} />;
+    default:
+      return null;
+  }
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,13 +6,15 @@ import {
   CityDefinition,
   Difficulty,
 } from './types';
-import { Start } from './scenes/Start';
-import { CreateKaiju } from './scenes/CreateKaiju';
-import { SelectCity } from './scenes/SelectCity';
-import { Level } from './scenes/Level';
-import { Score } from './scenes/Score';
-import { HighScores } from './scenes/HighScores';
-import { Options } from './scenes/Options';
+import {
+  Start,
+  CreateKaiju,
+  SelectCity,
+  Level,
+  Score,
+  HighScores,
+  Options,
+} from './scenes';
 import './App.css';
 
 type Scene =

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,9 @@ import React, { useState } from 'react';
 import {
   KaijuConfig,
   ScoreRecord,
+  GameSettings,
+  CityDefinition,
+  Difficulty,
 } from './types';
 import { Start } from './scenes/Start';
 import { CreateKaiju } from './scenes/CreateKaiju';
@@ -9,19 +12,26 @@ import { SelectCity } from './scenes/SelectCity';
 import { Level } from './scenes/Level';
 import { Score } from './scenes/Score';
 import { HighScores } from './scenes/HighScores';
+import { Options } from './scenes/Options';
 import './App.css';
 
 type Scene =
   | { name: 'start' }
   | { name: 'create' }
+  | { name: 'options' }
   | { name: 'select'; config: KaijuConfig }
-  | { name: 'level'; config: KaijuConfig; city: string }
+  | { name: 'level'; config: KaijuConfig; city: CityDefinition }
   | { name: 'score'; score: number }
   | { name: 'highscores' };
 
 function App() {
   const [scene, setScene] = useState<Scene>({ name: 'start' });
   const [scores, setScores] = useState<ScoreRecord[]>([]);
+  const [settings, setSettings] = useState<GameSettings>({
+    music: true,
+    sfx: true,
+    difficulty: Difficulty.Normal,
+  });
 
   switch (scene.name) {
     case 'start':
@@ -29,12 +39,23 @@ function App() {
         <Start
           onStartGame={() => setScene({ name: 'create' })}
           onViewHighScores={() => setScene({ name: 'highscores' })}
+          onOptions={() => setScene({ name: 'options' })}
         />
       );
     case 'create':
       return (
         <CreateKaiju
           onContinue={(config) => setScene({ name: 'select', config })}
+        />
+      );
+    case 'options':
+      return (
+        <Options
+          settings={settings}
+          onClose={(s) => {
+            setSettings(s);
+            setScene({ name: 'start' });
+          }}
         />
       );
     case 'select':
@@ -54,7 +75,7 @@ function App() {
             const record: ScoreRecord = {
               id: Date.now().toString(),
               kaiju: scene.config,
-              city: scene.city,
+              cityId: scene.city.id,
               score,
               createdAt: new Date().toISOString(),
             };

--- a/src/data/cities.ts
+++ b/src/data/cities.ts
@@ -1,0 +1,6 @@
+import { CityDefinition, Difficulty } from '../types';
+
+export const cities: CityDefinition[] = [
+  { id: 'metroville', name: 'Metroville', difficulty: Difficulty.Easy, blocks: 3 },
+  { id: 'coast-city', name: 'Coast City', difficulty: Difficulty.Normal, blocks: 4 },
+];

--- a/src/scenes/CreateKaiju.test.tsx
+++ b/src/scenes/CreateKaiju.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CreateKaiju } from './CreateKaiju';
+
+test('uses a default name and blocks empty names', async () => {
+  const onContinue = jest.fn();
+  render(<CreateKaiju onContinue={onContinue} />);
+  const input = screen.getByPlaceholderText(/Name/i) as HTMLInputElement;
+  const button = screen.getByText(/Continue/i);
+
+  expect(input.value).not.toBe('');
+  expect(button).toBeEnabled();
+
+  await userEvent.clear(input);
+  expect(button).toBeDisabled();
+
+  await userEvent.type(input, 'Titan');
+  expect(button).toBeEnabled();
+  await userEvent.click(button);
+  expect(onContinue).toHaveBeenCalledWith(
+    expect.objectContaining({ name: 'Titan' })
+  );
+});

--- a/src/scenes/CreateKaiju.tsx
+++ b/src/scenes/CreateKaiju.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { KaijuConfig } from '../types';
+
+interface Props {
+  onContinue: (config: KaijuConfig) => void;
+}
+
+const defaultConfig: KaijuConfig = {
+  name: '',
+  arms: 'claws',
+  legs: 'biped',
+  weapon: 'fire',
+};
+
+export const CreateKaiju: React.FC<Props> = ({ onContinue }) => {
+  const [config, setConfig] = useState<KaijuConfig>(defaultConfig);
+
+  return (
+    <div className="menu create-kaiju">
+      <h2>Create Kaiju</h2>
+      <input
+        placeholder="Name"
+        value={config.name}
+        onChange={(e) => setConfig({ ...config, name: e.target.value })}
+      />
+      <div>
+        <label>Arms:</label>
+        <select
+          value={config.arms}
+          onChange={(e) =>
+            setConfig({ ...config, arms: e.target.value as KaijuConfig['arms'] })
+          }
+        >
+          <option value="claws">Claws</option>
+          <option value="club">Club</option>
+          <option value="tentacles">Tentacles</option>
+        </select>
+      </div>
+      <div>
+        <label>Legs:</label>
+        <select
+          value={config.legs}
+          onChange={(e) =>
+            setConfig({ ...config, legs: e.target.value as KaijuConfig['legs'] })
+          }
+        >
+          <option value="biped">Biped</option>
+          <option value="quad">Quad</option>
+          <option value="treads">Treads</option>
+        </select>
+      </div>
+      <div>
+        <label>Weapon:</label>
+        <select
+          value={config.weapon}
+          onChange={(e) =>
+            setConfig({
+              ...config,
+              weapon: e.target.value as KaijuConfig['weapon'],
+            })
+          }
+        >
+          <option value="fire">Fire Breath</option>
+          <option value="laser">Laser Eyes</option>
+          <option value="poison">Poison Darts</option>
+        </select>
+      </div>
+      <button onClick={() => onContinue(config)}>Continue</button>
+    </div>
+  );
+};

--- a/src/scenes/CreateKaiju.tsx
+++ b/src/scenes/CreateKaiju.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { KaijuConfig } from '../types';
+import {
+  KaijuConfig,
+  ArmType,
+  LegType,
+  WeaponType,
+  ARM_OPTIONS,
+  LEG_OPTIONS,
+  WEAPON_OPTIONS,
+} from '../types';
 
 interface Props {
   onContinue: (config: KaijuConfig) => void;
@@ -9,9 +17,9 @@ const KAIJU_NAMES = ['Boulderback', 'Steamjaw', 'Razorwing', 'Pyronox', 'Gigacla
 
 const defaultConfig: KaijuConfig = {
   name: KAIJU_NAMES[Math.floor(Math.random() * KAIJU_NAMES.length)],
-  arms: 'claws',
-  legs: 'biped',
-  weapon: 'fire',
+  arms: ArmType.Claws,
+  legs: LegType.Biped,
+  weapon: WeaponType.Fire,
 };
 
 export const CreateKaiju: React.FC<Props> = ({ onContinue }) => {
@@ -36,12 +44,14 @@ export const CreateKaiju: React.FC<Props> = ({ onContinue }) => {
         <select
           value={config.arms}
           onChange={(e) =>
-            setConfig({ ...config, arms: e.target.value as KaijuConfig['arms'] })
+            setConfig({ ...config, arms: e.target.value as ArmType })
           }
         >
-          <option value="claws">Claws</option>
-          <option value="club">Club</option>
-          <option value="tentacles">Tentacles</option>
+          {ARM_OPTIONS.map(({ value, label }) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
         </select>
       </div>
       <div>
@@ -49,12 +59,14 @@ export const CreateKaiju: React.FC<Props> = ({ onContinue }) => {
         <select
           value={config.legs}
           onChange={(e) =>
-            setConfig({ ...config, legs: e.target.value as KaijuConfig['legs'] })
+            setConfig({ ...config, legs: e.target.value as LegType })
           }
         >
-          <option value="biped">Biped</option>
-          <option value="quad">Quad</option>
-          <option value="treads">Treads</option>
+          {LEG_OPTIONS.map(({ value, label }) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
         </select>
       </div>
       <div>
@@ -62,15 +74,14 @@ export const CreateKaiju: React.FC<Props> = ({ onContinue }) => {
         <select
           value={config.weapon}
           onChange={(e) =>
-            setConfig({
-              ...config,
-              weapon: e.target.value as KaijuConfig['weapon'],
-            })
+            setConfig({ ...config, weapon: e.target.value as WeaponType })
           }
         >
-          <option value="fire">Fire Breath</option>
-          <option value="laser">Laser Eyes</option>
-          <option value="poison">Poison Darts</option>
+          {WEAPON_OPTIONS.map(({ value, label }) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
         </select>
       </div>
       <button disabled={!config.name.trim()} onClick={handleContinue}>

--- a/src/scenes/CreateKaiju.tsx
+++ b/src/scenes/CreateKaiju.tsx
@@ -5,8 +5,10 @@ interface Props {
   onContinue: (config: KaijuConfig) => void;
 }
 
+const KAIJU_NAMES = ['Boulderback', 'Steamjaw', 'Razorwing', 'Pyronox', 'Gigaclaw'];
+
 const defaultConfig: KaijuConfig = {
-  name: '',
+  name: KAIJU_NAMES[Math.floor(Math.random() * KAIJU_NAMES.length)],
   arms: 'claws',
   legs: 'biped',
   weapon: 'fire',
@@ -14,6 +16,12 @@ const defaultConfig: KaijuConfig = {
 
 export const CreateKaiju: React.FC<Props> = ({ onContinue }) => {
   const [config, setConfig] = useState<KaijuConfig>(defaultConfig);
+
+  const handleContinue = () => {
+    const name = config.name.trim();
+    if (!name) return;
+    onContinue({ ...config, name });
+  };
 
   return (
     <div className="menu create-kaiju">
@@ -65,7 +73,9 @@ export const CreateKaiju: React.FC<Props> = ({ onContinue }) => {
           <option value="poison">Poison Darts</option>
         </select>
       </div>
-      <button onClick={() => onContinue(config)}>Continue</button>
+      <button disabled={!config.name.trim()} onClick={handleContinue}>
+        Continue
+      </button>
     </div>
   );
 };

--- a/src/scenes/HighScores.tsx
+++ b/src/scenes/HighScores.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ScoreRecord } from '../types';
+
+interface Props {
+  scores: ScoreRecord[];
+  onBack: () => void;
+}
+
+export const HighScores: React.FC<Props> = ({ scores, onBack }) => (
+  <div className="menu high-scores">
+    <h2>High Scores</h2>
+    <ol>
+      {scores.map((s) => (
+        <li key={s.id}>
+          {s.kaiju.name}: ${s.score}
+        </li>
+      ))}
+    </ol>
+    <button onClick={onBack}>Back</button>
+  </div>
+);

--- a/src/scenes/HighScores.tsx
+++ b/src/scenes/HighScores.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ScoreRecord } from '../types';
+import { cities } from '../data/cities';
 
 interface Props {
   scores: ScoreRecord[];
@@ -12,7 +13,9 @@ export const HighScores: React.FC<Props> = ({ scores, onBack }) => (
     <ol>
       {scores.map((s) => (
         <li key={s.id}>
-          {s.kaiju.name}: ${s.score}
+          {s.kaiju.name} in {
+            cities.find((c) => c.id === s.cityId)?.name || s.cityId
+          }: ${s.score}
         </li>
       ))}
     </ol>

--- a/src/scenes/Level.tsx
+++ b/src/scenes/Level.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { KaijuConfig } from '../types';
+
+interface Props {
+  config: KaijuConfig;
+  city: string;
+  onGameOver: (score: number) => void;
+}
+
+export const Level: React.FC<Props> = ({ config, city, onGameOver }) => {
+  return (
+    <div className="level-screen">
+      <h2>Rampage in {city}</h2>
+      <div className="sprites">
+        <img src="/kaiju.svg" alt="kaiju" />
+        <img src="/city.svg" alt="city" />
+      </div>
+      <button onClick={() => onGameOver(0)}>End</button>
+    </div>
+  );
+};

--- a/src/scenes/Level.tsx
+++ b/src/scenes/Level.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { KaijuConfig } from '../types';
+import { KaijuConfig, CityDefinition } from '../types';
 
 interface Props {
   config: KaijuConfig;
-  city: string;
+  city: CityDefinition;
   onGameOver: (score: number) => void;
 }
 
 export const Level: React.FC<Props> = ({ config, city, onGameOver }) => {
   return (
     <div className="level-screen">
-      <h2>Rampage in {city}</h2>
+      <h2>Rampage in {city.name}</h2>
       <div className="sprites">
         <img src="/kaiju.svg" alt="kaiju" />
         <img src="/city.svg" alt="city" />

--- a/src/scenes/Options.tsx
+++ b/src/scenes/Options.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import {
+  GameSettings,
+  Difficulty,
+  DIFFICULTY_OPTIONS,
+} from '../types';
+
+interface Props {
+  settings: GameSettings;
+  onClose: (settings: GameSettings) => void;
+}
+
+export const Options: React.FC<Props> = ({ settings, onClose }) => {
+  const [local, setLocal] = useState<GameSettings>(settings);
+
+  return (
+    <div className="menu options-menu">
+      <h2>Options</h2>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={local.music}
+            onChange={(e) => setLocal({ ...local, music: e.target.checked })}
+          />
+          Music
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={local.sfx}
+            onChange={(e) => setLocal({ ...local, sfx: e.target.checked })}
+          />
+          Sound Effects
+        </label>
+      </div>
+      <div>
+        <label>Difficulty:</label>
+        <select
+          value={local.difficulty}
+          onChange={(e) =>
+            setLocal({ ...local, difficulty: e.target.value as Difficulty })
+          }
+        >
+          {DIFFICULTY_OPTIONS.map((d) => (
+            <option key={d} value={d}>
+              {d.charAt(0).toUpperCase() + d.slice(1)}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button onClick={() => onClose(local)}>Back</button>
+    </div>
+  );
+};

--- a/src/scenes/Score.tsx
+++ b/src/scenes/Score.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface Props {
+  score: number;
+  onPlayAgain: () => void;
+  onViewHighScores: () => void;
+}
+
+export const Score: React.FC<Props> = ({ score, onPlayAgain, onViewHighScores }) => (
+  <div className="menu score-screen">
+    <h2>Score</h2>
+    <p>${score.toLocaleString()}</p>
+    <button onClick={onPlayAgain}>Play Again</button>
+    <button onClick={onViewHighScores}>High Scores</button>
+  </div>
+);

--- a/src/scenes/SelectCity.tsx
+++ b/src/scenes/SelectCity.tsx
@@ -1,21 +1,28 @@
 import React, { useState } from 'react';
+import { cities } from '../data/cities';
+import { CityDefinition } from '../types';
 
 interface Props {
-  onBegin: (city: string) => void;
+  onBegin: (city: CityDefinition) => void;
 }
 
-const cities = ['Metroville', 'Coast City'];
-
 export const SelectCity: React.FC<Props> = ({ onBegin }) => {
-  const [city, setCity] = useState(cities[0]);
+  const [city, setCity] = useState<CityDefinition>(cities[0]);
 
   return (
     <div className="menu select-city">
       <h2>Select City</h2>
-      <select value={city} onChange={(e) => setCity(e.target.value)}>
+      <select
+        value={city.id}
+        onChange={(e) =>
+          setCity(
+            cities.find((c) => c.id === e.target.value) as CityDefinition
+          )
+        }
+      >
         {cities.map((c) => (
-          <option key={c} value={c}>
-            {c}
+          <option key={c.id} value={c.id}>
+            {c.name}
           </option>
         ))}
       </select>

--- a/src/scenes/SelectCity.tsx
+++ b/src/scenes/SelectCity.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onBegin: (city: string) => void;
+}
+
+const cities = ['Metroville', 'Coast City'];
+
+export const SelectCity: React.FC<Props> = ({ onBegin }) => {
+  const [city, setCity] = useState(cities[0]);
+
+  return (
+    <div className="menu select-city">
+      <h2>Select City</h2>
+      <select value={city} onChange={(e) => setCity(e.target.value)}>
+        {cities.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+      <button onClick={() => onBegin(city)}>Begin Rampage</button>
+    </div>
+  );
+};

--- a/src/scenes/Start.tsx
+++ b/src/scenes/Start.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface Props {
+  onStartGame: () => void;
+  onViewHighScores: () => void;
+}
+
+export const Start: React.FC<Props> = ({ onStartGame, onViewHighScores }) => (
+  <div className="menu start-menu">
+    <h1>Kaiju Sidescroller</h1>
+    <button onClick={onStartGame}>Start Game</button>
+    <button onClick={onViewHighScores}>High Scores</button>
+  </div>
+);

--- a/src/scenes/Start.tsx
+++ b/src/scenes/Start.tsx
@@ -3,12 +3,18 @@ import React from 'react';
 interface Props {
   onStartGame: () => void;
   onViewHighScores: () => void;
+  onOptions: () => void;
 }
 
-export const Start: React.FC<Props> = ({ onStartGame, onViewHighScores }) => (
+export const Start: React.FC<Props> = ({
+  onStartGame,
+  onViewHighScores,
+  onOptions,
+}) => (
   <div className="menu start-menu">
     <h1>Kaiju Sidescroller</h1>
     <button onClick={onStartGame}>Start Game</button>
     <button onClick={onViewHighScores}>High Scores</button>
+    <button onClick={onOptions}>Options</button>
   </div>
 );

--- a/src/scenes/index.ts
+++ b/src/scenes/index.ts
@@ -1,0 +1,8 @@
+export { Start } from './Start';
+export { CreateKaiju } from './CreateKaiju';
+export { SelectCity } from './SelectCity';
+export { Level } from './Level';
+export { Score } from './Score';
+export { HighScores } from './HighScores';
+export { Options } from './Options';
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,69 @@
-export type WeaponType = 'fire' | 'laser' | 'poison';
+export enum WeaponType {
+  Fire = 'fire',
+  Laser = 'laser',
+  Poison = 'poison',
+}
+
+export enum ArmType {
+  Claws = 'claws',
+  Club = 'club',
+  Tentacles = 'tentacles',
+}
+
+export enum LegType {
+  Biped = 'biped',
+  Quad = 'quad',
+  Treads = 'treads',
+}
+
+export enum Difficulty {
+  Easy = 'easy',
+  Normal = 'normal',
+  Hard = 'hard',
+}
+
+export const ARM_OPTIONS = [
+  { value: ArmType.Claws, label: 'Claws' },
+  { value: ArmType.Club, label: 'Club' },
+  { value: ArmType.Tentacles, label: 'Tentacles' },
+];
+
+export const LEG_OPTIONS = [
+  { value: LegType.Biped, label: 'Biped' },
+  { value: LegType.Quad, label: 'Quad' },
+  { value: LegType.Treads, label: 'Treads' },
+];
+
+export const WEAPON_OPTIONS = [
+  { value: WeaponType.Fire, label: 'Fire Breath' },
+  { value: WeaponType.Laser, label: 'Laser Eyes' },
+  { value: WeaponType.Poison, label: 'Poison Darts' },
+];
+
+export const DIFFICULTY_OPTIONS = [
+  Difficulty.Easy,
+  Difficulty.Normal,
+  Difficulty.Hard,
+];
 
 export interface KaijuConfig {
   name: string;
-  arms: 'claws' | 'club' | 'tentacles';
-  legs: 'biped' | 'quad' | 'treads';
+  arms: ArmType;
+  legs: LegType;
   weapon: WeaponType;
+}
+
+export interface CityDefinition {
+  id: string;
+  name: string;
+  difficulty: Difficulty;
+  blocks: number;
 }
 
 export interface ScoreRecord {
   id: string;
   kaiju: KaijuConfig;
-  city: string;
+  cityId: string;
   score: number;
   createdAt: string;
 }
@@ -18,5 +71,5 @@ export interface ScoreRecord {
 export interface GameSettings {
   music: boolean;
   sfx: boolean;
-  difficulty: 'easy' | 'normal' | 'hard';
+  difficulty: Difficulty;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,22 @@
+export type WeaponType = 'fire' | 'laser' | 'poison';
+
+export interface KaijuConfig {
+  name: string;
+  arms: 'claws' | 'club' | 'tentacles';
+  legs: 'biped' | 'quad' | 'treads';
+  weapon: WeaponType;
+}
+
+export interface ScoreRecord {
+  id: string;
+  kaiju: KaijuConfig;
+  city: string;
+  score: number;
+  createdAt: string;
+}
+
+export interface GameSettings {
+  music: boolean;
+  sfx: boolean;
+  difficulty: 'easy' | 'normal' | 'hard';
+}


### PR DESCRIPTION
## Summary
- Add data models for kaiju config, scores, and settings
- Introduce basic scene components and navigation for start, creation, selection, level, score, and high scores
- Include placeholder kaiju and city sprites with simple styles
- Switch placeholder sprites to lightweight SVG assets

## Testing
- `npm test`
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68978d4baf34832a9ded08753ab4cd65