### PR TITLE
Add kaiju-themed responsive layout and logo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Kaiju Creator</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.css
+++ b/src/App.css
@@ -1,25 +1,76 @@
 .App {
   text-align: center;
-  color: white;
-  background-color: #282c34;
+  color: #fff;
+  background: url('./city.svg') repeat-x bottom/contain #1a1a1a;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  padding: 1rem;
 }
 
-.menu button {
+.app-header {
+  margin-bottom: 1rem;
+}
+
+.logo {
+  width: min(80vw, 400px);
+  height: auto;
+}
+
+.menu {
+  background: rgba(0, 0, 0, 0.6);
+  padding: 1rem 2rem;
+  border: 2px solid #e63946;
+  box-shadow: 0 0 10px #e63946;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+button {
+  background: #e63946;
+  border: none;
+  color: #fff;
+  font-size: 1.2rem;
+  padding: 0.5rem 1rem;
   margin: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  width: 200px;
+}
+
+button:hover {
+  background: #ff6b6b;
 }
 
 .level-screen {
-  color: white;
+  color: #fff;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .sprites img {
   width: 32px;
   height: 32px;
   margin: 0.5rem;
+}
+
+.tagline {
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+}
+
+@media (max-width: 600px) {
+  .menu {
+    width: 90%;
+    padding: 1rem;
+  }
+
+  button {
+    width: 100%;
+  }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -18,6 +18,20 @@
   height: auto;
 }
 
+.game-area {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: min(90vw, 900px);
+  background: rgba(0, 0, 0, 0.7);
+  border: 8px solid #e63946;
+  box-shadow: 0 0 20px #e63946;
+  border-radius: 16px;
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
 .menu {
   background: rgba(0, 0, 0, 0.6);
   padding: 1rem 2rem;
@@ -27,6 +41,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
+  max-width: 400px;
 }
 
 button {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import {
   Options,
 } from './scenes';
 import './App.css';
+import logo from './logo.svg';
 
 type Scene =
   | { name: 'start' }
@@ -35,23 +36,26 @@ function App() {
     difficulty: Difficulty.Normal,
   });
 
+  let currentScene: React.ReactNode = null;
   switch (scene.name) {
     case 'start':
-      return (
+      currentScene = (
         <Start
           onStartGame={() => setScene({ name: 'create' })}
           onViewHighScores={() => setScene({ name: 'highscores' })}
           onOptions={() => setScene({ name: 'options' })}
         />
       );
+      break;
     case 'create':
-      return (
+      currentScene = (
         <CreateKaiju
           onContinue={(config) => setScene({ name: 'select', config })}
         />
       );
+      break;
     case 'options':
-      return (
+      currentScene = (
         <Options
           settings={settings}
           onClose={(s) => {
@@ -60,16 +64,18 @@ function App() {
           }}
         />
       );
+      break;
     case 'select':
-      return (
+      currentScene = (
         <SelectCity
           onBegin={(city) =>
             setScene({ name: 'level', config: scene.config, city })
           }
         />
       );
+      break;
     case 'level':
-      return (
+      currentScene = (
         <Level
           config={scene.config}
           city={scene.city}
@@ -86,19 +92,31 @@ function App() {
           }}
         />
       );
+      break;
     case 'score':
-      return (
+      currentScene = (
         <Score
           score={scene.score}
           onPlayAgain={() => setScene({ name: 'start' })}
           onViewHighScores={() => setScene({ name: 'highscores' })}
         />
       );
+      break;
     case 'highscores':
-      return <HighScores scores={scores} onBack={() => setScene({ name: 'start' })} />;
-    default:
-      return null;
+      currentScene = (
+        <HighScores scores={scores} onBack={() => setScene({ name: 'start' })} />
+      );
+      break;
   }
+
+  return (
+    <div className="App">
+      <header className="app-header">
+        <img src={logo} className="logo" alt="Kaiju Creator logo" />
+      </header>
+      {currentScene}
+    </div>
+  );
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,7 +114,7 @@ function App() {
       <header className="app-header">
         <img src={logo} className="logo" alt="Kaiju Creator logo" />
       </header>
-      {currentScene}
+      <div className="game-area">{currentScene}</div>
     </div>
   );
 }

--- a/src/city.svg
+++ b/src/city.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="0" y="50" width="100" height="50" fill="gray" />
+  <rect x="10" y="40" width="20" height="60" fill="silver" />
+  <rect x="40" y="30" width="20" height="70" fill="lightgray" />
+  <rect x="70" y="45" width="20" height="55" fill="darkgray" />
+</svg>

--- a/src/city.svg
+++ b/src/city.svg
@@ -1,6 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect x="0" y="50" width="100" height="50" fill="gray" />
-  <rect x="10" y="40" width="20" height="60" fill="silver" />
-  <rect x="40" y="30" width="20" height="70" fill="lightgray" />
-  <rect x="70" y="45" width="20" height="55" fill="darkgray" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
+  <defs>
+    <linearGradient id="night" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#111" />
+      <stop offset="100%" stop-color="#000" />
+    </linearGradient>
+    <pattern id="windows" width="6" height="8" patternUnits="userSpaceOnUse">
+      <rect width="3" height="3" fill="#ffd166" />
+    </pattern>
+  </defs>
+  <rect width="200" height="100" fill="url(#night)" />
+  <g stroke="#000" stroke-width="2">
+    <rect x="5" y="40" width="25" height="60" fill="#4d4d4d" />
+    <rect x="40" y="25" width="35" height="75" fill="#595959" />
+    <polygon points="80,55 80,100 110,100 110,45 95,45 95,35 85,35 85,45" fill="#404040" />
+    <rect x="115" y="30" width="40" height="70" fill="#4a4a4a" />
+    <rect x="160" y="45" width="30" height="55" fill="#555" />
+  </g>
+  <g fill="url(#windows)">
+    <rect x="5" y="40" width="25" height="60" />
+    <rect x="40" y="25" width="35" height="75" />
+    <rect x="80" y="45" width="30" height="55" />
+    <rect x="115" y="30" width="40" height="70" />
+    <rect x="160" y="45" width="30" height="55" />
+  </g>
 </svg>

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Impact', 'Arial Black', sans-serif;
+  background: radial-gradient(circle at top, #3a3a3a, #000) fixed;
+  color: #f8f8f8;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/logo.svg
+++ b/src/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 120">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        font-family="Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif"
+        font-size="60" fill="#e63946" stroke="#000" stroke-width="4">
+    Kaiju Creator
+  </text>
+</svg>

--- a/src/logo.svg
+++ b/src/logo.svg
@@ -1,7 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 120">
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
-        font-family="Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif"
-        font-size="60" fill="#e63946" stroke="#000" stroke-width="4">
-    Kaiju Creator
-  </text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 150">
+  <g stroke="#000" stroke-width="4" fill="#e63946">
+    <path d="M40 120 L60 80 L80 60 L100 40 L130 45 L145 30 L160 45 L185 50 L205 80 L230 90 L220 110 L180 120 Z" />
+    <circle cx="150" cy="60" r="12" fill="#fff" />
+    <circle cx="150" cy="60" r="5" fill="#000" />
+    <path d="M135 90 L155 95 L145 105 Z" fill="#fff" />
+  </g>
+  <text x="260" y="95" font-family="Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif"
+        font-size="48" fill="#e63946" stroke="#000" stroke-width="4">Kaiju Creator</text>
 </svg>

--- a/src/scenes/Start.tsx
+++ b/src/scenes/Start.tsx
@@ -12,7 +12,7 @@ export const Start: React.FC<Props> = ({
   onOptions,
 }) => (
   <div className="menu start-menu">
-    <h1>Kaiju Sidescroller</h1>
+    <p className="tagline">Unleash your monster!</p>
     <button onClick={onStartGame}>Start Game</button>
     <button onClick={onViewHighScores}>High Scores</button>
     <button onClick={onOptions}>Options</button>


### PR DESCRIPTION
## Summary
- Add Kaiju Creator SVG logo and display it across all scenes
- Restyle app with dark rampage theme and responsive layout
- Update start screen copy and HTML title

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897da3576a0832a86d09cfed41e5cc4