### PR TITLE
Implement basic level gameplay loop

### DIFF
--- a/public/kaiju.svg
+++ b/public/kaiju.svg
@@ -1,6 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="40" fill="green" />
-  <circle cx="35" cy="40" r="5" fill="white" />
-  <circle cx="65" cy="40" r="5" fill="white" />
-  <rect x="45" y="60" width="10" height="15" fill="red" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <ellipse cx="60" cy="70" rx="35" ry="40" fill="#4caf50" />
+  <ellipse cx="40" cy="65" rx="10" ry="20" fill="#4caf50" />
+  <ellipse cx="80" cy="65" rx="10" ry="20" fill="#4caf50" />
+  <circle cx="50" cy="50" r="5" fill="#fff" />
+  <circle cx="70" cy="50" r="5" fill="#fff" />
+  <path d="M50 55 Q60 65 70 55" stroke="#f44336" stroke-width="4" fill="none" />
+  <rect x="55" y="90" width="10" height="20" fill="#f44336" />
 </svg>

--- a/src/App.css
+++ b/src/App.css
@@ -14,8 +14,10 @@
 }
 
 .level-screen {
-  color: white;
+  color: #000;
+  background: #fff;
   text-align: center;
+  width: 100%;
 }
 
 .sprites img {

--- a/src/scenes/Level.tsx
+++ b/src/scenes/Level.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { KaijuConfig, CityDefinition } from '../types';
 
 interface Props {
@@ -7,15 +7,160 @@ interface Props {
   onGameOver: (score: number) => void;
 }
 
+interface Enemy {
+  id: number;
+  x: number;
+  type: 'tank' | 'heli';
+  damage: number;
+  value: number;
+}
+
+const PLAYER_X = 100; // px from left
+const WORLD_SPEED = 100; // px / sec
+const BLOCK_LENGTH = 1000; // world units per city block
+const ENEMY_SPAWN_MS = 2000;
+
 export const Level: React.FC<Props> = ({ config, city, onGameOver }) => {
+  const [score, setScore] = useState(0);
+  const [health, setHealth] = useState(100);
+  const [enemies, setEnemies] = useState<Enemy[]>([]);
+
+  // refs to avoid stale closures in RAF loop
+  const enemiesRef = useRef<Enemy[]>(enemies);
+  const scoreRef = useRef(0);
+  const healthRef = useRef(100);
+  const progressRef = useRef(0);
+  const lastSpawnRef = useRef(0);
+  const frameRef = useRef<number>(0);
+
+  useEffect(() => {
+    enemiesRef.current = enemies;
+  }, [enemies]);
+
+  useEffect(() => {
+    scoreRef.current = score;
+  }, [score]);
+
+  useEffect(() => {
+    healthRef.current = health;
+  }, [health]);
+
+  const spawnEnemy = () => {
+    const id = Date.now() + Math.random();
+    const enemy: Enemy = {
+      id,
+      x: 800,
+      type: Math.random() < 0.5 ? 'tank' : 'heli',
+      damage: 10,
+      value: 1000,
+    };
+    enemiesRef.current.push(enemy);
+    setEnemies([...enemiesRef.current]);
+  };
+
+  // simple input handler: space to attack
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.code === 'Space') {
+        const idx = enemiesRef.current.findIndex(
+          (enemy) => enemy.x - PLAYER_X < 80
+        );
+        if (idx !== -1) {
+          const [enemy] = enemiesRef.current.splice(idx, 1);
+          setScore(scoreRef.current + enemy.value);
+          setEnemies([...enemiesRef.current]);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, []);
+
+  useEffect(() => {
+    let last = performance.now();
+
+    const update = (time: number) => {
+      const dt = (time - last) / 1000;
+      last = time;
+
+      progressRef.current += WORLD_SPEED * dt;
+
+      if (time - lastSpawnRef.current > ENEMY_SPAWN_MS) {
+        lastSpawnRef.current = time;
+        spawnEnemy();
+      }
+
+      enemiesRef.current.forEach((enemy) => {
+        enemy.x -= WORLD_SPEED * dt;
+      });
+
+      enemiesRef.current = enemiesRef.current.filter((enemy) => {
+        if (enemy.x <= PLAYER_X) {
+          const newHealth = healthRef.current - enemy.damage;
+          setHealth(newHealth);
+          return false;
+        }
+        return true;
+      });
+      setEnemies([...enemiesRef.current]);
+
+      if (
+        healthRef.current <= 0 ||
+        progressRef.current >= city.blocks * BLOCK_LENGTH
+      ) {
+        onGameOver(scoreRef.current);
+        return;
+      }
+
+      frameRef.current = requestAnimationFrame(update);
+    };
+
+    frameRef.current = requestAnimationFrame(update);
+    return () => {
+      if (frameRef.current) cancelAnimationFrame(frameRef.current);
+    };
+  }, [city.blocks, onGameOver]);
+
   return (
     <div className="level-screen">
       <h2>Rampage in {city.name}</h2>
-      <div className="sprites">
-        <img src="/kaiju.svg" alt="kaiju" />
-        <img src="/city.svg" alt="city" />
+      <div className="hud">
+        <div>Health: {health}</div>
+        <div>Score: ${score}</div>
+        <div>
+          Blocks: {Math.floor(progressRef.current / BLOCK_LENGTH)} / {city.blocks}
+        </div>
       </div>
-      <button onClick={() => onGameOver(0)}>End</button>
+      <div
+        className="playfield"
+        style={{
+          position: 'relative',
+          width: 800,
+          height: 300,
+          overflow: 'hidden',
+          background: '#88c',
+        }}
+      >
+        <img
+          src="/kaiju.svg"
+          alt={config.name}
+          style={{ position: 'absolute', left: PLAYER_X, bottom: 0 }}
+        />
+        {enemies.map((enemy) => (
+          <div
+            key={enemy.id}
+            className={`enemy enemy-${enemy.type}`}
+            style={{
+              position: 'absolute',
+              left: enemy.x,
+              bottom: 0,
+              width: 40,
+              height: 40,
+              background: enemy.type === 'tank' ? 'green' : 'gray',
+            }}
+          />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add requestAnimationFrame-driven gameplay loop for Level scene
- spawn enemies, handle simple combat input, update health and score HUD

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897da80100c832a90413095b346d30c